### PR TITLE
feat(auditoria): configurar auditoría con JPA

### DIFF
--- a/src/main/java/com/clinicavillegas/app/audit/AudityEntity.java
+++ b/src/main/java/com/clinicavillegas/app/audit/AudityEntity.java
@@ -1,0 +1,26 @@
+package com.clinicavillegas.app.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AudityEntity {
+
+    @CreatedDate
+    @Column(nullable = false, name = "fecha_creacion", updatable = false)
+    private LocalDateTime fechaCreacion;
+
+    @LastModifiedDate
+    @Column(nullable = false, name = "fecha_modificacion")
+    private LocalDateTime fechaModificacion;
+
+}

--- a/src/main/java/com/clinicavillegas/app/audit/JpaConfig.java
+++ b/src/main/java/com/clinicavillegas/app/audit/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.clinicavillegas.app.audit;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
Se creó una clase abstracta AuditableEntity con campos auditables y una clase JpaConfig para habilitar la auditoría mediante la anotación @EnableJpaAuditing.

Esta configuración permite registrar automáticamente en qué momento se creó o se modificó el recurso, mejorando la trazabilidad de los datos.