### PR TITLE
feat(seguridad): Protección de rutas

### DIFF
--- a/src/main/java/com/clinicavillegas/app/auth/config/SecurityConfig.java
+++ b/src/main/java/com/clinicavillegas/app/auth/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package com.clinicavillegas.app.auth.config;
 
+import com.clinicavillegas.app.common.EndpointPaths;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,15 +28,63 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
         return http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         authRequest -> authRequest
-                                .requestMatchers("/**").permitAll()
+                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                                .requestMatchers(deepMatcher(EndpointPaths.USUARIO_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasAnyRole("PACIENTE", "DENTISTA", "ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.TRATAMIENTO_BASE)).hasAnyRole("PACIENTE", "DENTISTA", "ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.TIPO_DOCUMENTO_BASE)).permitAll()
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.TIPO_DOCUMENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.TIPO_DOCUMENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.TIPO_DOCUMENTO_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.DENTISTA_BASE)).permitAll()
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.TIPO_TRATAMIENTO_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.DENTISTA_BASE)).hasAnyRole("PACIENTE", "DENTISTA", "ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.DENTISTA_BASE)).hasRole("ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.DENTISTA_BASE)).hasAnyRole("DENTISTA", "ADMINISTRADOR")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.DENTISTA_BASE)).hasRole("ADMINISTRADOR")
+
+                                .requestMatchers(deepMatcher(EndpointPaths.HORARIO_BASE)).hasAnyRole("DENTISTA", "ADMINISTRADOR")
+
+                                .requestMatchers(deepMatcher(EndpointPaths.CITA_BASE)).hasAnyRole("PACIENTE", "DENTISTA", "ADMINISTRADOR")
+
+                                .requestMatchers(deepMatcher(EndpointPaths.AUTH_BASE)).permitAll()
+
+                                .requestMatchers(deepMatcher(EndpointPaths.EMAIL_BASE)).permitAll()
+
+                                .requestMatchers(deepMatcher(EndpointPaths.RENIEC_BASE)).permitAll()
+
+                                .requestMatchers(HttpMethod.GET, deepMatcher(EndpointPaths.CHAT_BASE)).permitAll()
+                                .requestMatchers(HttpMethod.POST, deepMatcher(EndpointPaths.CHAT_BASE)).hasAnyRole("PACIENTE", "DENTISTA")
+                                .requestMatchers(HttpMethod.PUT, deepMatcher(EndpointPaths.CHAT_BASE)).hasAnyRole("PACIENTE", "DENTISTA")
+                                .requestMatchers(HttpMethod.DELETE, deepMatcher(EndpointPaths.CHAT_BASE)).hasAnyRole("PACIENTE", "DENTISTA")
+
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    public static String deepMatcher(String endpoint){
+        return String.format("%s/**", endpoint);
     }
 }

--- a/src/main/java/com/clinicavillegas/app/auth/services/JwtService.java
+++ b/src/main/java/com/clinicavillegas/app/auth/services/JwtService.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 public class JwtService {
 
     @Value("${app.jwt.secret}")
-    public String SECRET_KEY;
+    private String SECRET_KEY;
 
     private final DentistaRepository dentistaRepository;
 

--- a/src/main/java/com/clinicavillegas/app/user/models/Usuario.java
+++ b/src/main/java/com/clinicavillegas/app/user/models/Usuario.java
@@ -64,7 +64,7 @@ public class Usuario extends AudityEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(rol.name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + rol.name()));
     }
 
     @Override


### PR DESCRIPTION
Se introduce todas la protecciones para la rutas del proyecto teniendo en cuenta los roles y permisos. Se introduce la autenticación necesaria en cada método de los endpoints si es necesario. Cumpliendo con el pilar de encapsulamiento, cambiamos el modificador de la variable de la llave cifrada de JWT a privada. Con esto se espera cumplir con la seguridad básica de la aplicación, evitar ataques CRSF y controlar las peticiones que llegan a la API.