### PR TITLE
chore : Creación de pipeline CI/CD .

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -5,51 +5,60 @@ on:
     branches: [ "main", "develop" ]
   pull_request:
     branches: [ "main", "develop" ]
-
-env:
-  DB_HOST: localhost
-  DB_PORT: 5432
-  FRONT_END_URL: http://localhost:4200
-  RENIEC_URL: https://api.apis.net.pe/v2/reniec/
-
+permissions:
+  contents: read
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    
+
     services:
       postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+        image: postgres:15
         ports:
           - 5432:5432
+        env:
+          POSTGRES_DB: testdb
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: clinicavillegas
+      DB_USER: postgres
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+      MAIL_USER: ${{ secrets.MAIL_USER }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+
+      FRONT_END_URL: http://localhost:4200
+      RENIEC_URL: https://api.apis.net.pe/v2/reniec/
+      RENIEC_TOKEN: ${{ secrets.RENIEC_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v3
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'maven'
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
-    - name: Build and test with Maven
-      run: mvn -B verify
-      env:
-        SPRING_DATASOURCE_URL: jdbc:postgresql://${{ env.DB_HOST }}:${{ env.DB_PORT }}/${{ secrets.POSTGRES_DB }}
-        SPRING_DATASOURCE_USERNAME: ${{ secrets.POSTGRES_USER }}
-        SPRING_DATASOURCE_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-        SPRING_JPA_HIBERNATE_DDL_AUTO: update
-        
-        MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
-        MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
-        
-        JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build and run tests
+        run: mvn clean verify

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -1,0 +1,55 @@
+name: CI/CD Pipeline for Spring Boot
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+env:
+  DB_HOST: localhost
+  DB_PORT: 5432
+  FRONT_END_URL: http://localhost:4200
+  RENIEC_URL: https://api.apis.net.pe/v2/reniec/
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build and test with Maven
+      run: mvn -B verify
+      env:
+        SPRING_DATASOURCE_URL: jdbc:postgresql://${{ env.DB_HOST }}:${{ env.DB_PORT }}/${{ secrets.POSTGRES_DB }}
+        SPRING_DATASOURCE_USERNAME: ${{ secrets.POSTGRES_USER }}
+        SPRING_DATASOURCE_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        SPRING_JPA_HIBERNATE_DDL_AUTO: update
+        
+        MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+        MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+        
+        JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}


### PR DESCRIPTION
Este commit añade un pipeline de GitHub Actions para CI/CD, enfocado en  pruebas unitarias y de integración de Spring Boot. Se activa en `push`/`pull_request` a `main`/`develop`, configura PostgreSQL y JDK 21, y ejecuta todas las pruebas con Maven, usando GitHub Secrets para credenciales sensibles. El objetivo es detectar errores temprano y asegurar la calidad e robustez del código.