### PR TITLE
bugfix(test): Arreglar pruebas de controladores

### DIFF
--- a/src/test/java/com/clinicavillegas/app/appointment/controllers/CitaControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/appointment/controllers/CitaControllerTest.java
@@ -5,6 +5,7 @@ import com.clinicavillegas.app.appointment.dto.request.CitaRequest;
 import com.clinicavillegas.app.appointment.dto.request.ValidacionCitaRequest;
 import com.clinicavillegas.app.appointment.dto.response.CitaResponse;
 import com.clinicavillegas.app.appointment.services.CitaService;
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +51,10 @@ public class CitaControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
     @Test

--- a/src/test/java/com/clinicavillegas/app/appointment/controllers/DentistaControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/appointment/controllers/DentistaControllerTest.java
@@ -3,6 +3,7 @@ package com.clinicavillegas.app.appointment.controllers;
 import com.clinicavillegas.app.appointment.dto.request.DentistaRequest;
 import com.clinicavillegas.app.appointment.dto.response.DentistaResponse;
 import com.clinicavillegas.app.appointment.services.DentistaService;
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,10 @@ public class DentistaControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/appointment/controllers/HorarioControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/appointment/controllers/HorarioControllerTest.java
@@ -3,6 +3,7 @@ package com.clinicavillegas.app.appointment.controllers;
 import com.clinicavillegas.app.appointment.dto.request.HorarioRequest;
 import com.clinicavillegas.app.appointment.dto.response.HorarioResponse;
 import com.clinicavillegas.app.appointment.services.HorarioService;
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,10 @@ public class HorarioControllerTest {
         @Bean
         public JwtService jwtService() {
             return Mockito.mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/appointment/controllers/TipoTratamientoControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/appointment/controllers/TipoTratamientoControllerTest.java
@@ -3,6 +3,7 @@ package com.clinicavillegas.app.appointment.controllers;
 import com.clinicavillegas.app.appointment.dto.request.TipoTratamientoRequest;
 import com.clinicavillegas.app.appointment.models.TipoTratamiento;
 import com.clinicavillegas.app.appointment.services.TipoTratamientoService;
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.clinicavillegas.app.common.EndpointPaths;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,6 +47,10 @@ public class TipoTratamientoControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/appointment/controllers/TratamientoControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/appointment/controllers/TratamientoControllerTest.java
@@ -3,6 +3,7 @@ package com.clinicavillegas.app.appointment.controllers;
 import com.clinicavillegas.app.appointment.dto.request.TratamientoRequest;
 import com.clinicavillegas.app.appointment.models.Tratamiento;
 import com.clinicavillegas.app.appointment.services.TratamientoService;
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,10 @@ public class TratamientoControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/chat/controllers/ComentarioControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/chat/controllers/ComentarioControllerTest.java
@@ -1,5 +1,6 @@
 package com.clinicavillegas.app.chat.controllers;
 
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.chat.dto.request.ComentarioRequest;
 import com.clinicavillegas.app.chat.dto.response.ComentarioResponse;
 import com.clinicavillegas.app.chat.services.ComentarioService;
@@ -47,6 +48,10 @@ public class ComentarioControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/email/controllers/EmailControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/email/controllers/EmailControllerTest.java
@@ -1,5 +1,6 @@
 package com.clinicavillegas.app.email.controllers;
 
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.clinicavillegas.app.email.dto.CodeRequest;
 import com.clinicavillegas.app.email.dto.EmailRequest;
@@ -46,6 +47,10 @@ public class EmailControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/user/controllers/ApiReniecControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/user/controllers/ApiReniecControllerTest.java
@@ -1,5 +1,6 @@
 package com.clinicavillegas.app.user.controllers;
 
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.clinicavillegas.app.user.services.ApiReniecService;
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +42,10 @@ public class ApiReniecControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 

--- a/src/test/java/com/clinicavillegas/app/user/controllers/TipoDocumentoControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/user/controllers/TipoDocumentoControllerTest.java
@@ -1,5 +1,6 @@
 package com.clinicavillegas.app.user.controllers;
 
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.clinicavillegas.app.user.dto.request.TipoDocumentoRequest;
 import com.clinicavillegas.app.user.models.TipoDocumento;
@@ -44,6 +45,10 @@ public class TipoDocumentoControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
     @Test

--- a/src/test/java/com/clinicavillegas/app/user/controllers/UsuarioControllerTest.java
+++ b/src/test/java/com/clinicavillegas/app/user/controllers/UsuarioControllerTest.java
@@ -1,5 +1,6 @@
 package com.clinicavillegas.app.user.controllers;
 
+import com.clinicavillegas.app.auth.services.CookieService;
 import com.clinicavillegas.app.auth.services.JwtService;
 import com.clinicavillegas.app.user.dto.request.UsuarioRequest;
 import com.clinicavillegas.app.user.dto.response.UsuarioResponse;
@@ -43,6 +44,10 @@ public class UsuarioControllerTest {
         @Bean
         public JwtService jwtService() {
             return mock(JwtService.class);
+        }
+        @Bean
+        public CookieService cookieService(){
+            return mock(CookieService.class);
         }
     }
 


### PR DESCRIPTION
Se corrige el error de obtención de beans de autenticación en las pruebas de los controladores de la aplicación. Con esto se asegura que las pruebas unitarias de los controladores funcionen correctamente al simular el contexto de seguridad nulo.