### PR TITLE
chore: Cambio del atributo SameSite en la cookie

### DIFF
--- a/src/main/java/com/clinicavillegas/app/auth/services/CookieService.java
+++ b/src/main/java/com/clinicavillegas/app/auth/services/CookieService.java
@@ -48,7 +48,7 @@ public class CookieService {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Strict")
+                .sameSite("None")
                 .path(path)
                 .maxAge(maxAge)
                 .build();


### PR DESCRIPTION
Esta carácterística permite que las cookies sean enviadas en todas las conexiones de un dominio, independientemente de la conexión de origen. Es importante tomar en cuenta que esta carácteristica puede ser temporal o permanente, dependiendo de la configuración del servidor.